### PR TITLE
Update veil and fix incompatability with Iris

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,2 @@
 - Updated Veil to 4.2.1 (Fixes incompatability with Sodium 0.8.12([16](https://github.com/BeeIsYou/map-drawing/issues/16)) )
+- Fixed map screen not rendering whenever an Iris shaderpack is active on newer versions of Veil

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,1 @@
-- Updated Veil to 4.0.0
+- Updated Veil to 4.2.1 (Fixes incompatability with Sodium 0.8.12([16](https://github.com/BeeIsYou/map-drawing/issues/16)) )

--- a/common/src/main/java/wawa/mapwright/Rendering.java
+++ b/common/src/main/java/wawa/mapwright/Rendering.java
@@ -24,6 +24,13 @@ import java.io.InputStream;
 
 public class Rendering {
 
+	/**
+	 * True for the duration of MapScreen's render pass. Works around in Veil's Iris
+	 * compat that redirects any Veil-shaded draw into an internal Iris
+	 * framebuffer whenever an Iris pipeline is registered. See {@link wawa.mapwright.mixin.compat.VeilIrisCompatFix }
+	 */
+	public static boolean inGuiShaderDraw = false;
+
 	public static class RenderTypes {
 		public static final ResourceLocation PALETTE_SWAP = MapwrightClient.id("palette_swap");
 		public static final ResourceLocation UV_REMAP = MapwrightClient.id("uv_remap");
@@ -55,16 +62,22 @@ public class Rendering {
 
 		final RenderType renderType = VeilRenderType.get(RenderTypes.UV_REMAP, skinTexture, Textures.HEAD_ICON);
 		if(renderType == null) return;
-		final ShaderUniform xOffset = VeilRenderSystem.setShader(Shaders.UV_REMAP).getUniform("XOffset");
 
-		final float rot = ((player.yRotO + 90) % 360) / 360.0f;
-		final int frame = Math.round(rot * 16);
+		Rendering.inGuiShaderDraw = true;
+		try {
+			final ShaderUniform xOffset = VeilRenderSystem.setShader(Shaders.UV_REMAP).getUniform("XOffset");
 
-		xOffset.setFloat(0.0f);
-		Rendering.renderTypeBlit(graphics, renderType, x, y, 0, 0.0f, 16.0f * frame, 16, 16, 16, 256, alpha);
+			final float rot = ((player.yRotO + 90) % 360) / 360.0f;
+			final int frame = Math.round(rot * 16);
 
-		xOffset.setFloat(0.5f);
-		Rendering.renderTypeBlit(graphics, renderType, x, y, 0, 0.0f, 16.0f * frame, 16, 16, 16, 256, alpha);
+			xOffset.setFloat(0.0f);
+			Rendering.renderTypeBlit(graphics, renderType, x, y, 0, 0.0f, 16.0f * frame, 16, 16, 16, 256, alpha);
+
+			xOffset.setFloat(0.5f);
+			Rendering.renderTypeBlit(graphics, renderType, x, y, 0, 0.0f, 16.0f * frame, 16, 16, 16, 256, alpha);
+		} finally {
+			Rendering.inGuiShaderDraw = false;
+		}
 	}
 
 	public static NativeImage getPaletteTexture() {
@@ -102,9 +115,9 @@ public class Rendering {
 	}
 
 	public static void renderTypeBlitUV1(final GuiGraphics guiGraphics, final RenderType renderType,
-										 final int x, final int y, final int width, final int height,
-										 final int textureWidth, final int textureHeight, final int blitOffset,
-										 final float u, final float v) {
+	                                     final int x, final int y, final int width, final int height,
+	                                     final int textureWidth, final int textureHeight, final int blitOffset,
+	                                     final float u, final float v) {
 		final Matrix4f matrix4f = guiGraphics.pose().last().pose();
 		final BufferBuilder bufferBuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_LIGHTMAP_COLOR);
 		bufferBuilder.addVertex(matrix4f, (float)x, (float)y, (float)blitOffset)

--- a/common/src/main/java/wawa/mapwright/map/MapScreen.java
+++ b/common/src/main/java/wawa/mapwright/map/MapScreen.java
@@ -17,6 +17,7 @@ import org.lwjgl.glfw.GLFW;
 import wawa.mapwright.Helper;
 import wawa.mapwright.LerpedVector2d;
 import wawa.mapwright.MapwrightClient;
+import wawa.mapwright.Rendering;
 import wawa.mapwright.map.stamp_bag.widgets.StampBagWidget;
 import wawa.mapwright.map.tool.PanTool;
 import wawa.mapwright.map.widgets.CompassWidget;
@@ -91,19 +92,24 @@ public class MapScreen extends Screen {
 
     @Override
     public void render(final GuiGraphics guiGraphics, final int mouseX, final int mouseY, final float partialTick) {
-        final Vector2d diffTracker = new Vector2d();
-        this.lerpedPanning.tickProgress(0.05 * Minecraft.getInstance().getTimer().getRealtimeDeltaTicks(), diffTracker);
-        this.backgroundPanning.add(diffTracker.mul(this.zoom));
+        Rendering.inGuiShaderDraw = true;
+        try {
+            final Vector2d diffTracker = new Vector2d();
+            this.lerpedPanning.tickProgress(0.05 * Minecraft.getInstance().getTimer().getRealtimeDeltaTicks(), diffTracker);
+            this.backgroundPanning.add(diffTracker.mul(this.zoom));
 
-        super.render(guiGraphics, mouseX, mouseY, partialTick);
+            super.render(guiGraphics, mouseX, mouseY, partialTick);
 
-        this.stampScreen.renderScreen(guiGraphics, mouseX, mouseY, partialTick);
+            this.stampScreen.renderScreen(guiGraphics, mouseX, mouseY, partialTick);
 
-        final Vec2 mouse = Helper.preciseMousePos();
-        guiGraphics.pose().pushPose();
-        guiGraphics.pose().translate(mouse.x % 1, mouse.y % 1, 0);
-        MapwrightClient.TOOL_MANAGER.get().renderScreen(guiGraphics, mouseX, mouseY);
-        guiGraphics.pose().popPose();
+            final Vec2 mouse = Helper.preciseMousePos();
+            guiGraphics.pose().pushPose();
+            guiGraphics.pose().translate(mouse.x % 1, mouse.y % 1, 0);
+            MapwrightClient.TOOL_MANAGER.get().renderScreen(guiGraphics, mouseX, mouseY);
+            guiGraphics.pose().popPose();
+        } finally {
+            Rendering.inGuiShaderDraw = false;
+        }
     }
 
     // widgets that are rendered last (on top) have the highest interaction priority

--- a/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/DualGUIElement.java
+++ b/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/DualGUIElement.java
@@ -1,6 +1,7 @@
 package wawa.mapwright.map.stamp_bag.widgets;
 
 import net.minecraft.client.gui.GuiGraphics;
+import wawa.mapwright.Rendering;
 import wawa.mapwright.gui.GUIElementAtlases;
 
 public class DualGUIElement extends GUIElementButton{
@@ -15,10 +16,15 @@ public class DualGUIElement extends GUIElementButton{
 
 	@Override
 	protected void renderWidget(final GuiGraphics guiGraphics, final int mouseX, final int mouseY, final float partialTick) {
-		if (this.imageSwitch) {
-            this.secondary.render(guiGraphics, this.getX(), this.getY());
-		} else {
-			super.renderWidget(guiGraphics, mouseX, mouseY, partialTick);
+		Rendering.inGuiShaderDraw = true;
+		try {
+			if (this.imageSwitch) {
+				this.secondary.render(guiGraphics, this.getX(), this.getY());
+			} else {
+				super.renderWidget(guiGraphics, mouseX, mouseY, partialTick);
+			}
+		} finally {
+			Rendering.inGuiShaderDraw = false;
 		}
 	}
 }

--- a/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/GUIElementButton.java
+++ b/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/GUIElementButton.java
@@ -3,6 +3,7 @@ package wawa.mapwright.map.stamp_bag.widgets;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
+import wawa.mapwright.Rendering;
 import wawa.mapwright.gui.GUIElementAtlases;
 
 public class GUIElementButton extends Button {
@@ -16,6 +17,12 @@ public class GUIElementButton extends Button {
 
     @Override
     protected void renderWidget(final GuiGraphics guiGraphics, final int mouseX, final int mouseY, final float partialTick) {
-        this.texture.render(guiGraphics, this.getX(), this.getY());
+        Rendering.inGuiShaderDraw = true;
+        try {
+            this.texture.render(guiGraphics, this.getX(), this.getY());
+        } finally {
+            Rendering.inGuiShaderDraw = false;
+        }
+
     }
 }

--- a/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/StampBagWidget.java
+++ b/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/StampBagWidget.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
 import wawa.mapwright.MapwrightClient;
+import wawa.mapwright.Rendering;
 import wawa.mapwright.gui.GUIElementAtlases;
 import wawa.mapwright.map.MapScreen;
 import wawa.mapwright.map.StampBagScreen;
@@ -24,18 +25,23 @@ public class StampBagWidget extends AbstractWidget {
 
     @Override
     protected void renderWidget(final GuiGraphics guiGraphics, final int mouseX, final int mouseY, final float v) {
-        if ((this.mapScreen.toolPicker.getImageFromScissorTool() != null & MapwrightClient.TOOL_MANAGER.get() instanceof CopyTool)
-                || StampBagScreen.INSTANCE.getState() != StampBagScreen.ScreenState.IDLE) {
-            GUIElementAtlases.STAMP_BAG_OPEN.render(guiGraphics, this.getX(), this.getY());
-            if (this.isHovered) {
-                GUIElementAtlases.STAMP_BAG_OPEN_HIGHLIGHT.render(guiGraphics, this.getX() - 1, this.getY() - 1);
+        Rendering.inGuiShaderDraw = true;
+        try {
+            if ((this.mapScreen.toolPicker.getImageFromScissorTool() != null & MapwrightClient.TOOL_MANAGER.get() instanceof CopyTool)
+                    || StampBagScreen.INSTANCE.getState() != StampBagScreen.ScreenState.IDLE) {
+                GUIElementAtlases.STAMP_BAG_OPEN.render(guiGraphics, this.getX(), this.getY());
+                if (this.isHovered) {
+                    GUIElementAtlases.STAMP_BAG_OPEN_HIGHLIGHT.render(guiGraphics, this.getX() - 1, this.getY() - 1);
+                }
+            } else {
+                GUIElementAtlases.STAMP_BAG_CLOSED.render(guiGraphics, this.getX(), this.getY());
+                if (this.isHovered) {
+                    GUIElementAtlases.STAMP_BAG_CLOSED_HIGHLIGHT.render(guiGraphics, this.getX() - 1, this.getY() - 1);
+                    guiGraphics.renderTooltip(Minecraft.getInstance().font, Component.translatable("mapwright.tool.stamp"), mouseX, mouseY);
+                }
             }
-        } else {
-            GUIElementAtlases.STAMP_BAG_CLOSED.render(guiGraphics, this.getX(), this.getY());
-            if (this.isHovered) {
-                GUIElementAtlases.STAMP_BAG_CLOSED_HIGHLIGHT.render(guiGraphics, this.getX() - 1, this.getY() - 1);
-                guiGraphics.renderTooltip(Minecraft.getInstance().font, Component.translatable("mapwright.tool.stamp"), mouseX, mouseY);
-            }
+        } finally {
+            Rendering.inGuiShaderDraw = false;
         }
     }
 

--- a/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/StampEntryWidget.java
+++ b/common/src/main/java/wawa/mapwright/map/stamp_bag/widgets/StampEntryWidget.java
@@ -56,63 +56,67 @@ public class StampEntryWidget extends AbstractStampScreenWidget {
 
     @Override
     protected void renderWidget(final GuiGraphics guiGraphics, final int mx, final int my, final float v) {
-        if (this.stampInformation == null) {
-            return;
-        }
+        Rendering.inGuiShaderDraw = true;
+        try {
+            if (this.stampInformation == null) {
+                return;
+            }
 
-        final StampTexture manager = this.stampInformation.getTextureManager();
-        final NativeImage tex = manager.getTexture();
-        if (tex == null) {
-            return;
-        }
+            final StampTexture manager = this.stampInformation.getTextureManager();
+            final NativeImage tex = manager.getTexture();
+            if (tex == null) {
+                return;
+            }
 
-        if (!this.registered) {
-            this.registered = true;
-            Minecraft.getInstance().getTextureManager().register(this.id, manager);
-        }
+            if (!this.registered) {
+                this.registered = true;
+                Minecraft.getInstance().getTextureManager().register(this.id, manager);
+            }
 
-        final PoseStack ps = guiGraphics.pose();
-        ps.pushPose();
-        final RenderType renderType = VeilRenderType.get(Rendering.RenderTypes.PALETTE_SWAP, this.id);
-        if (renderType == null) {
-            return;
-        }
+            final RenderType renderType = VeilRenderType.get(Rendering.RenderTypes.PALETTE_SWAP, this.id);
+            if (renderType == null) {
+                return; // nothing pushed yet, safe
+            }
 
-        ps.pushPose();
-        //TODO:center
-        ps.translate(this.getX() + 1, this.getY() + 1, 0);
+            final PoseStack ps = guiGraphics.pose();
+            ps.pushPose();
+            //TODO:center
+            ps.translate(this.getX() + 1, this.getY() + 1, 0);
 
-        final float scale = Math.min(56f / tex.getWidth() / 2f, 56f / tex.getHeight() / 2f);
-        ps.scale(scale, scale, 1);
+            final float scale = Math.min(56f / tex.getWidth() / 2f, 56f / tex.getHeight() / 2f);
+            ps.scale(scale, scale, 1);
 
-        Rendering.renderTypeBlit(guiGraphics, renderType, 4.1, 4, 0, 0f, 0f,
-                manager.getTexture().getWidth(), manager.getTexture().getHeight(), manager.getTexture().getWidth(), manager.getTexture().getHeight(), 1);
-        ps.popPose();
-
-        ps.pushPose();
-        guiGraphics.enableScissor(this.getX() + 36, this.getY() + 5, this.getX() + 123, this.getY() + 27);
-        ps.translate(this.getX() + 38, this.getY() + 8, 0);
-        if (Minecraft.getInstance().font.width(this.stampInformation.getCustomName()) < 85) {
-            ps.translate(0, 4, 0);
-        }
-
-        // slight scale to handle wordwrap weirdness
-        ps.scale(1.05f, 1.05f, 1);
-
-        //TODO: scroll
-        guiGraphics.drawWordWrap(Minecraft.getInstance().font, FormattedText.of(this.stampInformation.getCustomName()), 0, 0, 85, Color.WHITE.getRGB());
-        guiGraphics.disableScissor();
-        ps.popPose();
-
-        if (this.isHovered()) {
-            ps.translate(0, 0, 10);
-            final int tx = mx - tex.getWidth() - 16;
-            final int ty = my - tex.getHeight() / 2;
-            guiGraphics.blitSprite(StampBagDebuggerTool.backgroundID, tx - 5, ty - 5, tex.getWidth() + 10, tex.getHeight() + 10);
-            Rendering.renderTypeBlit(guiGraphics, renderType, tx, ty, 0, 0f, 0f,
+            Rendering.renderTypeBlit(guiGraphics, renderType, 4.1, 4, 0, 0f, 0f,
                     manager.getTexture().getWidth(), manager.getTexture().getHeight(), manager.getTexture().getWidth(), manager.getTexture().getHeight(), 1);
-        }
+            ps.popPose();
 
-        ps.popPose();
+            ps.pushPose();
+            guiGraphics.enableScissor(this.getX() + 36, this.getY() + 5, this.getX() + 123, this.getY() + 27);
+            ps.translate(this.getX() + 38, this.getY() + 8, 0);
+            if (Minecraft.getInstance().font.width(this.stampInformation.getCustomName()) < 85) {
+                ps.translate(0, 4, 0);
+            }
+
+            // slight scale to handle wordwrap weirdness
+            ps.scale(1.05f, 1.05f, 1);
+
+            //TODO: scroll
+            guiGraphics.drawWordWrap(Minecraft.getInstance().font, FormattedText.of(this.stampInformation.getCustomName()), 0, 0, 85, Color.WHITE.getRGB());
+            guiGraphics.disableScissor();
+            ps.popPose();
+
+            if (this.isHovered()) {
+                ps.translate(0, 0, 10);
+                final int tx = mx - tex.getWidth() - 16;
+                final int ty = my - tex.getHeight() / 2;
+                guiGraphics.blitSprite(StampBagDebuggerTool.backgroundID, tx - 5, ty - 5, tex.getWidth() + 10, tex.getHeight() + 10);
+                Rendering.renderTypeBlit(guiGraphics, renderType, tx, ty, 0, 0f, 0f,
+                        manager.getTexture().getWidth(), manager.getTexture().getHeight(), manager.getTexture().getWidth(), manager.getTexture().getHeight(), 1);
+            }
+
+            ps.popPose();
+        } finally {
+            Rendering.inGuiShaderDraw = false;
+        }
     }
 }

--- a/common/src/main/java/wawa/mapwright/mixin/compat/VeilIrisCompatFix.java
+++ b/common/src/main/java/wawa/mapwright/mixin/compat/VeilIrisCompatFix.java
@@ -1,0 +1,28 @@
+package wawa.mapwright.mixin.compat;
+
+import foundry.veil.impl.client.render.shader.program.ShaderProgramImpl;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import wawa.mapwright.Rendering;
+
+@Mixin(value = ShaderProgramImpl.Wrapper.class, priority = 2000)
+public class VeilIrisCompatFix {
+
+    /**
+     * Veil's Iris compat ({@code ShaderWrapperMixin}) breaks map rendering by redireecting
+     * every draw made with a Veil shader into an internal Iris offscreen framebuffer whenever
+     * a shaderpack is active, and the geometry ends up rendered into a buffer that's never
+     * displayed.
+     * <p>
+     * Re-binds the correct render target immediately after Veil's redirect.
+     */
+    @Inject(method = "apply", at = @At("TAIL"))
+    private void beginBeatingVeilWithASteelPipe(CallbackInfo ci) {
+        if (Rendering.inGuiShaderDraw) {
+            Minecraft.getInstance().getMainRenderTarget().bindWrite(true);
+        }
+    }
+}

--- a/common/src/main/resources/mapwright.mixins.json
+++ b/common/src/main/resources/mapwright.mixins.json
@@ -15,7 +15,8 @@
     "coordinates_config.DebugScreenOverlayMixin",
     "coordinates_config.GuiMixin",
     "coordinates_config.KeyboardHandlerMixin",
-    "coordinates_config.PlayerMixin"
+    "coordinates_config.PlayerMixin",
+    "compat.VeilIrisCompatFix"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Every field you add must be added to the root build.gradle expandProps map.
 
 # Project
-version=1.0.6
+version=1.0.7
 group=wawa.mapwright
 java_version=21
 
@@ -22,7 +22,7 @@ neo_form_version=1.21.1-20240808.144430
 parchment_minecraft=1.21.1
 parchment_version = 2024.11.17
 
-veil_version = 4.0.0
+veil_version = 4.2.1
 dh_version = 2.4.5-b
 dh_api_version = 5.1.0
 fcap_version=21.1.6


### PR DESCRIPTION
### Changes
- Updated veil from 4.0.0 to 4.2.1 (Closes #16 )
- Fixed map screen not rendering whenever Iris shaderpack is active

Veil 4.0.1 introduced compatibility mixin (`foundry.veil.forge.mixin.compat.iris.ShaderWrapperMixin`) 
which redirects every draw made with a Veil shader into an Iris's internal
offscreen framebuffer.
Any Mapwright GUI draw that uses a Veil shader was getting silently 
rendered into a buffer that's never displayed.

### Fix
- Added `Rendering.inGuiShaderDraw`, set for the duration of
  `MapScreen#render` (covers everything drawn in the menu).
- Added `VeilIrisCompatFix` mixin which re-binds main render target
  right after Veil's redirect, but only while the flag is set - so
  genuine in-world Veil+Iris rendering is untouched.